### PR TITLE
Cut version 0.1.0 of landscapes before changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
     "name": "OpenWhere",
     "url": "http://www.openwhere.com"
   },
+  "scripts": {
+    "postversion": "git push origin master && git push origin --tags",
+    "start": "grunt",
+    "test": "grunt test"
+  },
   "contributors": [
     {
       "name": "Andy Heifetz",
@@ -98,8 +103,5 @@
   },
   "engines": {
     "node": "*"
-  },
-  "scripts": {
-    "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landscapes.io",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Manage and deploy AWS CloudFormation templates.",
   "homepage": "http://www.landscapes.io",
   "bugs": {


### PR DESCRIPTION
I may need to push tags to upstream after this pull request is merged, but I wanted to make sure that we have a paper trail in commit messages :+1: 